### PR TITLE
cas server url may contains numbers, improving the regexp

### DIFF
--- a/src/web/web_site.ml
+++ b/src/web/web_site.ml
@@ -443,7 +443,7 @@ let create_new_election owner cred auth =
 let () = Html.register ~service:election_draft_pre
   (fun () () -> T.election_draft_pre ())
 
-let http_rex = "^https?://[a-z/.-]+$"
+let http_rex = "^https?://[a-z0-9/.-]+$"
 
 let is_http_url =
   let rex = Pcre.regexp ~flags:[`CASELESS] http_rex in


### PR DESCRIPTION
The regexp was accepting only letters slash dot and dash for the name of the cas server, it may also contains numbers. Otherwise a cas server like cas1.example.org will be rejected and the admin of an election will see the error message "Bas CAS Server!".