### PR TITLE
Minor changes in sending e-mails

### DIFF
--- a/src/web/pages_voter.ml
+++ b/src/web/pages_voter.ml
@@ -745,7 +745,7 @@ let cast_confirmed election ~result () =
   ] in
   let result, step_title =
     match result with
-    | Ok (hash, weight) ->
+    | Ok (hash, weight, email) ->
        let your_weight_is =
          if not Weight.(is_int weight 1) then
            span [
@@ -765,7 +765,7 @@ let cast_confirmed election ~result () =
         txt (s_ "You can check its presence in the ");
         a ~service:election_pretty_ballots [txt (s_ "ballot box")] (uuid, ());
         txt (s_ " anytime during the election.");
-        txt (s_ " A confirmation e-mail has been sent to you.");
+        txt (if email then s_ " A confirmation e-mail has been sent to you." else "");
        ], s_ "Thank you for voting!"
     | Error e ->
        [txt (s_ " is rejected, because ");

--- a/src/web/pages_voter.mli
+++ b/src/web/pages_voter.mli
@@ -29,7 +29,7 @@ val election_home : (module ELECTION_DATA) -> election_state -> unit -> [> `Html
 val cast_raw : (module ELECTION_DATA) -> unit -> [> `Html ] Eliom_content.Html.F.elt Lwt.t
 val cast_confirmation : (module ELECTION_DATA) -> string -> unit -> [> `Html ] Eliom_content.Html.F.elt Lwt.t
 val lost_ballot : (module ELECTION_DATA) -> unit -> [> `Html ] Eliom_content.Html.F.elt Lwt.t
-val cast_confirmed : (module ELECTION_DATA) -> result:(string * Weight.t, Web_common.error) result -> unit -> [> `Html ] Eliom_content.Html.F.elt Lwt.t
+val cast_confirmed : (module ELECTION_DATA) -> result:(string * Weight.t * bool, Web_common.error) result -> unit -> [> `Html ] Eliom_content.Html.F.elt Lwt.t
 val pretty_ballots : (module ELECTION_DATA) -> [> `Html ] Eliom_content.Html.F.elt Lwt.t
 
 val booth : unit -> [> `Html ] Eliom_content.Html.F.elt Lwt.t

--- a/src/web/site_voter.ml
+++ b/src/web/site_voter.ml
@@ -152,7 +152,11 @@ let send_confirmation_email uuid revote user recipient weight hash =
   let open (val l) in
   let subject = Printf.sprintf (f_ "Your vote for election %s") title in
   let body = Pages_voter.mail_confirmation l user title weight hash revote url1 url2 metadata in
-  send_email (MailConfirmation uuid) ~recipient ~subject ~body
+  Lwt.catch
+    (fun () ->
+      let* () = send_email (MailConfirmation uuid) ~recipient ~subject ~body in
+      Lwt.return true)
+    (fun _ -> Lwt.return false)
 
 let cast_ballot uuid ~rawballot ~user =
   let* voters = read_file ~uuid "voters.txt" in
@@ -180,7 +184,8 @@ let cast_ballot uuid ~rawballot ~user =
   let* r = Web_persist.cast_ballot uuid ~rawballot ~user ~weight (now ()) in
   match r with
   | Ok (hash, revote) ->
-     let* () = send_confirmation_email uuid revote login email oweight hash in
+     let* _success = send_confirmation_email uuid revote login email oweight hash in
+     (* TODO: warn that no confirmation e-mail have been sent *)
      return (hash, weight)
   | Error e ->
      let msg = match e with

--- a/src/web/site_voter.ml
+++ b/src/web/site_voter.ml
@@ -184,9 +184,8 @@ let cast_ballot uuid ~rawballot ~user =
   let* r = Web_persist.cast_ballot uuid ~rawballot ~user ~weight (now ()) in
   match r with
   | Ok (hash, revote) ->
-     let* _success = send_confirmation_email uuid revote login email oweight hash in
-     (* TODO: warn that no confirmation e-mail have been sent *)
-     return (hash, weight)
+     let* success = send_confirmation_email uuid revote login email oweight hash in
+     return (hash, weight, success)
   | Error e ->
      let msg = match e with
        | ECastWrongCredential -> Some "attempted to revote with already used credential"

--- a/src/web/web_common.ml
+++ b/src/web/web_common.ml
@@ -330,9 +330,12 @@ let send_email kind ~recipient ~subject ~body =
       (fun () -> Lwt_preemptive.detach sendmail contents)
       (function
        | Unix.Unix_error (Unix.EAGAIN, _, _) when retry > 0 ->
+          Ocsigen_messages.warning "Failed to fork for sending an e-mail; will try again in 1s";
           let* () = Lwt_unix.sleep 1. in
           loop (retry - 1)
-       | e -> Lwt.fail e
+       | e ->
+          Ocsigen_messages.errlog ("Failed to send an e-mail: " ^ Printexc.to_string e);
+          Lwt.fail e
       )
   in loop 2
 

--- a/src/web/web_common.ml
+++ b/src/web/web_common.ml
@@ -325,16 +325,16 @@ let send_email kind ~recipient ~subject ~body =
   in
   let return_path = !Web_config.return_path in
   let sendmail = sendmail ?return_path in
-  let rec loop () =
+  let rec loop retry =
     Lwt.catch
       (fun () -> Lwt_preemptive.detach sendmail contents)
       (function
-       | Unix.Unix_error (Unix.EAGAIN, _, _) ->
+       | Unix.Unix_error (Unix.EAGAIN, _, _) when retry > 0 ->
           let* () = Lwt_unix.sleep 1. in
-          loop ()
+          loop (retry - 1)
        | e -> Lwt.fail e
       )
-  in loop ()
+  in loop 2
 
 let available_languages = [
     "en"; "fr"; "de"; "ro"; "it";

--- a/src/web/web_state.mli
+++ b/src/web/web_state.mli
@@ -30,7 +30,7 @@ val election_user : (uuid * user) option Eliom_reference.eref
 val get_election_user : uuid -> user option Lwt.t
 
 val ballot : string option Eliom_reference.eref
-val cast_confirmed : (string * Weight.t, Web_common.error) result option Eliom_reference.eref
+val cast_confirmed : (string * Weight.t * bool, Web_common.error) result option Eliom_reference.eref
 
 val language : string option Eliom_reference.eref
 


### PR DESCRIPTION
This PR tries to improve a bit the experience of the admin of a Belenios server.

1. There is an infinite loop while `Lwt_preemptive.detach` fails: I think it does not make sense to retry forever. (Moreover, the client is waiting for a reply…)
2. Nothing is ever written to the Ocsigen logs.
3. IMHO, failing at sending the confirmation e-mail after the successful cast of a ballot is not critical. In the current situation, the ballot is correctly registered by the server but no confirmation is sent and the server never replies.