### PR TITLE
Small fix: Fix reference_template.json missing coma

### DIFF
--- a/contrib/reference_template.json
+++ b/contrib/reference_template.json
@@ -13,7 +13,7 @@
     "/static/mime.types"        : null,
     "/static/placeholder.png"   : null,
     "/static/site.bundle.css"   : null,
-    "/static/booth.bundle.css"  : null
+    "/static/booth.bundle.css"  : null,
     "/static/tool_js.js"        : null,
     "/static/tool_js_booth.js"  : null,
     "/static/tool_js_credgen.js"        : null,


### PR DESCRIPTION
I found what seems like a syntax error
Not sure that this is relevant though