### PR TITLE
Election export and import as a draft from a json file

### DIFF
--- a/src/web/clients/admin/admin.ml
+++ b/src/web/clients/admin/admin.ml
@@ -307,46 +307,46 @@ let rec page_body () =
                 alert ("Creation failed: " ^ string_of_error e);
                 Lwt.return_unit))
   in
-  let file_elt = Tyxml_js.Html.input ~a:[
-    a_input_type `File; a_style "display:none;"
-  ] () in
+  let file_elt =
+    Tyxml_js.Html.input ~a:[ a_input_type `File; a_style "display:none;" ] ()
+  in
   let file_dom = Tyxml_js.To_dom.of_input file_elt in
-  let () = file_dom##.onchange := lwt_handler (fun _ ->
-    let files = file_dom##.files in
-    let files = Js.Optdef.get files (fun () -> assert false) in
-    if files##.length = 0 then
-      Lwt.return_unit
-    else
-      let file = files##item 0 in
-      let file = Js.Opt.get file  (fun () -> assert false) in
-      let* text = Common.read_full file in
-      let text = Js.to_string text in
-      let* x = post_with_token text "drafts"
-        |> wrap uuid_of_string
-      in
-      match x with
-      | Ok uuid ->
-          where_am_i := Election { uuid; status = Draft; tab = Title };
-          Dom_html.window##.location##.hash
-          := Js.string (Uuid.unwrap uuid);
-          Lwt.return_unit
-      | Error e ->
-          alert ("Creation failed: "
-            ^ Belenios_js.Session.(string_of_error e));
-          Lwt.return_unit
-  ) in
+  let () =
+    file_dom##.onchange :=
+      lwt_handler (fun _ ->
+          let files = file_dom##.files in
+          let files = Js.Optdef.get files (fun () -> assert false) in
+          if files##.length = 0 then Lwt.return_unit
+          else
+            let file = files##item 0 in
+            let file = Js.Opt.get file (fun () -> assert false) in
+            let* text = Common.read_full file in
+            let text = Js.to_string text in
+            let* x = post_with_token text "drafts" |> wrap uuid_of_string in
+            match x with
+            | Ok uuid ->
+                where_am_i := Election { uuid; status = Draft; tab = Title };
+                Dom_html.window##.location##.hash
+                := Js.string (Uuid.unwrap uuid);
+                Lwt.return_unit
+            | Error e ->
+                alert
+                  ("Creation failed: " ^ Belenios_js.Session.(string_of_error e));
+                Lwt.return_unit)
+  in
   let button_import =
     button
       ~a:[ a_class [ "clickable" ] ]
       (s_ "Import an election")
-      (fun () -> 
+      (fun () ->
         let file_unsafe = Js.Unsafe.coerce file_dom in
-        let () = file_unsafe##click() in
+        let () = file_unsafe##click () in
         Lwt.return_unit)
   in
-  let menus = div ~a:[ a_class [ "main-menu__button" ] ] [
-    but_cr; button_import
-  ] :: menus in
+  let menus =
+    div ~a:[ a_class [ "main-menu__button" ] ] [ but_cr; button_import ]
+    :: menus
+  in
   let main_menu = div ~a:[ a_id "main_menu"; a_class [ "main-menu" ] ] menus in
   Lwt.return
     [

--- a/src/web/clients/admin/common.ml
+++ b/src/web/clients/admin/common.ml
@@ -47,6 +47,7 @@ type tab =
   | ElectionPage
   | CreateOpenClose
   | Tally
+  | Export
   | Destroy
 
 type status = Draft | Running | Tallied | Archived
@@ -96,3 +97,16 @@ let url_prefix () =
       | Some pr -> pr)
 
 let default_version = Belenios.Election.(Version V1)
+
+let read_full file =
+  let t, u = Lwt.task () in
+  let reader = new%js File.fileReader in
+  reader##.onload :=
+    Dom.handler (fun _ ->
+        let () =
+          let$ text = File.CoerceTo.string reader##.result in
+          Lwt.wakeup_later u text
+        in
+        Js._false);
+  reader##readAsText file;
+  t

--- a/src/web/clients/admin/common.mli
+++ b/src/web/clients/admin/common.mli
@@ -19,6 +19,7 @@
 (*  <http://www.gnu.org/licenses/>.                                       *)
 (**************************************************************************)
 
+open Js_of_ocaml
 open Belenios_core.Common
 
 (** Session management *)
@@ -40,6 +41,7 @@ type tab =
   | ElectionPage
   | CreateOpenClose
   | Tally
+  | Export
   | Destroy
 
 type status = Draft | Running | Tallied | Archived
@@ -63,3 +65,4 @@ val is_finished : unit -> bool
 val popup_failsync : string -> unit Lwt.t
 val url_prefix : unit -> string
 val default_version : Belenios.Election.some_version
+val read_full : #File.blob Js.t -> Js.js_string Js.t Lwt.t


### PR DESCRIPTION
This PR address issue #65.

It adds a new tab to export an election (or a draft) as json.
The election will be transformed to the draft format.

![image](https://github.com/glondu/belenios/assets/4403587/f88f4762-e8e2-4b07-abee-2424f3c8717a)

The file containing the election as json can then be imported to create a new draft with all the necessary informations.

![image](https://github.com/glondu/belenios/assets/4403587/d36d00f6-fc56-483f-99df-c9ba4584bd08)