### PR TITLE
Do not throw an error if unable to save questions

### DIFF
--- a/src/web/clients/admin/cache.ml
+++ b/src/web/clients/admin/cache.ml
@@ -101,21 +101,23 @@ let sync_one x =
         let content_str = x.to_string content in
         let ifmatch = x.ifmatch in
         match !where_am_i with
-        | Election {uuid; _} -> (
-          let url = match x.endpoint with
-          | Plain x -> x
-          | WithUuid { fmt } -> Printf.sprintf fmt (Uuid.unwrap uuid)
-          in
-          let* y = put_with_token ~ifmatch content_str "%s" url in
-          match y.code with
-          | 200 ->
-              x.dirty <- false;
-              x.ifmatch <- sha256_b64 content_str;
-              Lwt.return @@ Ok ()
-          | code ->
-              Lwt.return
-              @@ Error
-                   (Printf.sprintf "Failed to sync data to server, code %d" code))
+        | Election { uuid; _ } -> (
+            let url =
+              match x.endpoint with
+              | Plain x -> x
+              | WithUuid { fmt } -> Printf.sprintf fmt (Uuid.unwrap uuid)
+            in
+            let* y = put_with_token ~ifmatch content_str "%s" url in
+            match y.code with
+            | 200 ->
+                x.dirty <- false;
+                x.ifmatch <- sha256_b64 content_str;
+                Lwt.return @@ Ok ()
+            | code ->
+                Lwt.return
+                @@ Error
+                     (Printf.sprintf "Failed to sync data to server, code %d"
+                        code))
         | _ -> Lwt.return @@ Ok ())
 
 (***********************************)


### PR DESCRIPTION
Issue #80

With unsaved questions
When leaving the admin/election page (for example by clicking on "Home")
It fails to update the election because `get_current_uuid` is incorrectly set to `Uuid.dummy` since we exited the form.

This is a quick fix to avoid the error when this case occurs.