### PR TITLE
Fix the elections/ballots endpoint

### DIFF
--- a/src/web/server/common/web_auth.ml
+++ b/src/web/server/common/web_auth.ml
@@ -402,7 +402,7 @@ struct
     match List.assoc_opt c.auth_system !auth_systems with
     | Some { handler; _ } ->
         let module X = (val handler (Some uuid) c) in
-        let* user_name = X.direct x in
+        let* user_name = X.direct s x in
         Lwt.return { user_name; user_domain = c.auth_instance }
     | None -> fail ()
 

--- a/src/web/server/common/web_auth_dummy.ml
+++ b/src/web/server/common/web_auth_dummy.ml
@@ -38,7 +38,7 @@ struct
         in
         return (Web_auth_sig.Html page, Web_auth.No_data)
 
-      let direct x =
+      let direct _ x =
         let fail () = failwith "invalid direct dummy authentication" in
         match x with
         | `Assoc x -> (

--- a/src/web/server/common/web_auth_email.ml
+++ b/src/web/server/common/web_auth_email.ml
@@ -89,7 +89,8 @@ struct
               in
               return (Web_auth_sig.Html fragment, Web_auth.No_data)
 
-      let direct _ = failwith "direct authentication not implemented for email"
+      let direct _ _ =
+        failwith "direct authentication not implemented for email"
     end in
     (module X : Web_auth_sig.AUTH_SYSTEM)
 

--- a/src/web/server/common/web_auth_oidc.ml
+++ b/src/web/server/common/web_auth_oidc.ml
@@ -116,7 +116,7 @@ struct
             return (Web_auth_sig.Redirection url, Data_oidc ocfg)
         | _ -> failwith "oidc_login_handler invoked with bad config"
 
-      let direct _ =
+      let direct _ _ =
         failwith "direct authentication not implemented for OpenID Connect"
     end in
     (module X : Web_auth_sig.AUTH_SYSTEM)

--- a/src/web/server/common/web_auth_sig.mli
+++ b/src/web/server/common/web_auth_sig.mli
@@ -33,7 +33,7 @@ module type AUTH_SYSTEM = sig
   val pre_login_handler :
     [ `Username | `Address ] -> state:string -> (result * data) Lwt.t
 
-  val direct : Yojson.Safe.t -> string Lwt.t
+  val direct : Storage.t -> Yojson.Safe.t -> string Lwt.t
 end
 
 type auth_system = {


### PR DESCRIPTION
Pass already acquired transactional backend to the auth handler in order to avoid starting a nested transaction and deadlocking the mutex.

Top-level transaction is started in `dispatch` (api_eliom.ml). The storage is then passed to `direct_voter_auth`. However, it is not passed further to auth handler `direct`. Instead `check` in web_auth_password.ml would attempt to start another transaction, trying to take the same mutex and deadlocking the web-server. This would also cause denial-of-service for subsequent requests, so this patch fixes it.