### PR TITLE
Modernize admin and booth UI styling

### DIFF
--- a/frontend/booth/app.css
+++ b/frontend/booth/app.css
@@ -22,15 +22,30 @@
 
 body {
   background: var(--body-background);
-  font-family: Arial, Helvetica, sans-serif;
-  font-weight: lighter;
-  line-height: initial;
+  background-image: radial-gradient(at 0% 0%, rgba(79, 70, 229, 0.06) 0px, transparent 50%),
+                    radial-gradient(at 100% 0%, rgba(14, 165, 233, 0.05) 0px, transparent 50%);
+  background-attachment: fixed;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-weight: 400;
+  color: var(--font-dark);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1,
 h2,
 h3 {
-  font-family: "Ubuntu", arial, serif;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", arial, serif;
+  letter-spacing: -0.01em;
+}
+
+a {
+  color: var(--accent);
+  transition: color 0.15s ease;
+}
+a:hover {
+  color: var(--accent-hover);
 }
 
 @media screen and (max-width: 640px) {
@@ -57,10 +72,11 @@ input[type="text"] {
 }
 
 .page {
-  max-width: 800px;
+  max-width: 880px;
   margin: 0 auto;
   box-shadow: var(--page-shadow);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
 }
 
 .page-body {

--- a/frontend/booth/components/CandidateWithCheckbox.css
+++ b/frontend/booth/components/CandidateWithCheckbox.css
@@ -2,13 +2,14 @@
 
 .candidate-with-checkbox {
   background-color: var(--candidate-background);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   height: 55px;
-  margin-bottom: 7px;
+  margin-bottom: 8px;
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   width: 100%;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .candidate-with-checkbox--with-alert {
@@ -17,6 +18,7 @@
 
 .candidate-with-checkbox:hover {
   background-color: var(--candidate-background-hover);
+  box-shadow: var(--box-shadow);
 }
 
 .candidate-with-checkbox label {
@@ -24,7 +26,8 @@
   display: flex;
   align-items: center;
   padding: 10px 20px;
-  border-radius: 7px;
+  border-radius: var(--radius-md);
+  transition: background-color 0.15s ease;
 }
 
 /* Customize appearance of checkboxes (by hiding it and replacing its UI with a span.checkbox-appearance) */

--- a/frontend/booth/components/NiceButton.css
+++ b/frontend/booth/components/NiceButton.css
@@ -12,7 +12,7 @@ input[type="reset"]:not(.nice-button) {
   line-height: 1.4;
   color: var(--font-dark);
   background: var(--background-light);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-input);
   border-radius: var(--radius-md);
   padding: 7px 14px;
   box-shadow: var(--button-shadow);
@@ -59,6 +59,7 @@ input[type="reset"]:not(.nice-button)[disabled] {
   opacity: 0.55;
   cursor: not-allowed;
   background: var(--surface-subtle);
+  border-color: var(--border-subtle);
   color: var(--font-muted);
   box-shadow: none;
   transform: none;

--- a/frontend/booth/components/NiceButton.css
+++ b/frontend/booth/components/NiceButton.css
@@ -1,22 +1,117 @@
+/* Default styling for bare <button> and input[type=submit|button|reset]
+   elements (the admin SPA uses unstyled buttons via Common.button).
+   The .nice-button family below stays untouched thanks to :not(). */
+button:not(.nice-button),
+input[type="submit"]:not(.nice-button),
+input[type="button"]:not(.nice-button),
+input[type="reset"]:not(.nice-button) {
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--font-dark);
+  background: var(--background-light);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 7px 14px;
+  box-shadow: var(--button-shadow);
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    box-shadow 0.2s ease, color 0.15s ease, transform 0.05s ease;
+  letter-spacing: 0.01em;
+}
+
+button:not(.nice-button):hover,
+input[type="submit"]:not(.nice-button):hover,
+input[type="button"]:not(.nice-button):hover,
+input[type="reset"]:not(.nice-button):hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: var(--button-shadow-hover);
+  transform: translateY(-1px);
+}
+
+button:not(.nice-button):active,
+input[type="submit"]:not(.nice-button):active,
+input[type="button"]:not(.nice-button):active,
+input[type="reset"]:not(.nice-button):active {
+  transform: translateY(0);
+  box-shadow: var(--button-shadow);
+}
+
+button:not(.nice-button):focus-visible,
+input[type="submit"]:not(.nice-button):focus-visible,
+input[type="button"]:not(.nice-button):focus-visible,
+input[type="reset"]:not(.nice-button):focus-visible {
+  outline: none;
+  box-shadow: var(--button-shadow), var(--focus-ring);
+}
+
+button:not(.nice-button):disabled,
+button:not(.nice-button)[disabled],
+input[type="submit"]:not(.nice-button):disabled,
+input[type="submit"]:not(.nice-button)[disabled],
+input[type="button"]:not(.nice-button):disabled,
+input[type="button"]:not(.nice-button)[disabled],
+input[type="reset"]:not(.nice-button):disabled,
+input[type="reset"]:not(.nice-button)[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: var(--surface-subtle);
+  color: var(--font-muted);
+  box-shadow: none;
+  transform: none;
+}
+
+button:not(.nice-button):disabled:hover,
+button:not(.nice-button)[disabled]:hover,
+input[type="submit"]:not(.nice-button):disabled:hover,
+input[type="submit"]:not(.nice-button)[disabled]:hover,
+input[type="button"]:not(.nice-button):disabled:hover,
+input[type="button"]:not(.nice-button)[disabled]:hover,
+input[type="reset"]:not(.nice-button):disabled:hover,
+input[type="reset"]:not(.nice-button)[disabled]:hover {
+  background: var(--surface-subtle);
+  color: var(--font-muted);
+  border-color: var(--border-subtle);
+  transform: none;
+  box-shadow: none;
+}
+
 .nice-button {
   border: 0;
-  padding: 6px 12px;
-  border-radius: 8px;
+  padding: 9px 18px;
+  border-radius: var(--radius-md);
   font-size: 15px;
-  font-weight: 400;
+  font-weight: 500;
   text-decoration: none;
   display: inline-block;
   line-height: initial;
   box-shadow: var(--button-shadow);
+  transition: background-color 0.15s ease, box-shadow 0.2s ease,
+    transform 0.05s ease;
+  letter-spacing: 0.01em;
 }
 
 .nice-button:hover {
   cursor: pointer;
   box-shadow: var(--button-shadow-hover);
+  transform: translateY(-1px);
+}
+.nice-button:active {
+  transform: translateY(0);
+  box-shadow: var(--button-shadow);
+}
+.nice-button:focus-visible {
+  outline: none;
+  box-shadow: var(--button-shadow), var(--focus-ring);
 }
 .nice-button[disabled]:hover {
   cursor: initial;
   background: initial;
+  transform: none;
+  box-shadow: var(--button-shadow);
 }
 
 .nice-button[disabled] {

--- a/frontend/booth/components/NiceInput.css
+++ b/frontend/booth/components/NiceInput.css
@@ -15,7 +15,7 @@ input[type="month"],
 input[type="week"],
 select {
   border-radius: var(--radius-md);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-input);
   padding: 9px 12px;
   background: var(--background-light);
   color: var(--font-dark);
@@ -51,7 +51,7 @@ input[type="datetime-local"]:hover,
 input[type="month"]:hover,
 input[type="week"]:hover,
 select:hover {
-  border-color: #cbd5e1;
+  border-color: var(--border-input-hover);
 }
 
 .nice-password-input:focus,
@@ -162,7 +162,7 @@ input[type="week"]:focus::-webkit-calendar-picker-indicator {
    built-in selector button to match the .nice-button family. */
 input[type="file"] {
   border-radius: var(--radius-md);
-  border: 1px dashed var(--border-subtle);
+  border: 1px dashed var(--border-input);
   padding: 6px 10px;
   background: var(--surface-subtle);
   color: var(--font-dark);

--- a/frontend/booth/components/NiceInput.css
+++ b/frontend/booth/components/NiceInput.css
@@ -1,6 +1,255 @@
 .nice-password-input,
-.nice-text-input {
-  border-radius: 8px;
-  border: 1px solid #c4c4c4;
-  padding: 5px 10px;
+.nice-text-input,
+textarea,
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="number"],
+input[type="search"],
+input[type="url"],
+input[type="tel"],
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"],
+input[type="month"],
+input[type="week"],
+select {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  padding: 9px 12px;
+  background: var(--background-light);
+  color: var(--font-dark);
+  font-size: 15px;
+  font-family: inherit;
+  line-height: 1.4;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease,
+    background-color 0.15s ease;
+  box-sizing: border-box;
 }
+
+textarea {
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 80px;
+  width: 100%;
+}
+
+.nice-password-input:hover,
+.nice-text-input:hover,
+textarea:hover,
+input[type="text"]:hover,
+input[type="password"]:hover,
+input[type="email"]:hover,
+input[type="number"]:hover,
+input[type="search"]:hover,
+input[type="url"]:hover,
+input[type="tel"]:hover,
+input[type="date"]:hover,
+input[type="time"]:hover,
+input[type="datetime-local"]:hover,
+input[type="month"]:hover,
+input[type="week"]:hover,
+select:hover {
+  border-color: #cbd5e1;
+}
+
+.nice-password-input:focus,
+.nice-text-input:focus,
+textarea:focus,
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="email"]:focus,
+input[type="number"]:focus,
+input[type="search"]:focus,
+input[type="url"]:focus,
+input[type="tel"]:focus,
+input[type="date"]:focus,
+input[type="time"]:focus,
+input[type="datetime-local"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04), var(--focus-ring);
+  background: var(--background-light);
+}
+
+.nice-password-input:disabled,
+.nice-text-input:disabled,
+textarea:disabled,
+input[type="text"]:disabled,
+input[type="password"]:disabled,
+input[type="email"]:disabled,
+input[type="number"]:disabled,
+input[type="search"]:disabled,
+input[type="url"]:disabled,
+input[type="tel"]:disabled,
+input[type="date"]:disabled,
+input[type="time"]:disabled,
+input[type="datetime-local"]:disabled,
+input[type="month"]:disabled,
+input[type="week"]:disabled,
+select:disabled {
+  background: var(--surface-subtle);
+  color: var(--font-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.nice-password-input[readonly],
+.nice-text-input[readonly],
+textarea[readonly],
+input[type="text"][readonly],
+input[type="password"][readonly],
+input[type="email"][readonly],
+input[type="number"][readonly],
+input[type="search"][readonly],
+input[type="url"][readonly],
+input[type="tel"][readonly] {
+  background: var(--surface-subtle);
+  color: var(--font-muted);
+}
+
+.nice-password-input::placeholder,
+.nice-text-input::placeholder,
+textarea::placeholder,
+input::placeholder {
+  color: var(--font-muted);
+  opacity: 1;
+}
+
+/* Number input: keep native spinners but make them less visually heavy */
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  opacity: 0.55;
+  transition: opacity 0.15s ease;
+}
+
+input[type="number"]:hover::-webkit-outer-spin-button,
+input[type="number"]:hover::-webkit-inner-spin-button,
+input[type="number"]:focus::-webkit-outer-spin-button,
+input[type="number"]:focus::-webkit-inner-spin-button {
+  opacity: 1;
+}
+
+/* Date/time picker indicator: subtle tint that lights up on hover/focus */
+input[type="date"]::-webkit-calendar-picker-indicator,
+input[type="time"]::-webkit-calendar-picker-indicator,
+input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+input[type="month"]::-webkit-calendar-picker-indicator,
+input[type="week"]::-webkit-calendar-picker-indicator {
+  opacity: 0.55;
+  cursor: pointer;
+  transition: opacity 0.15s ease, filter 0.15s ease;
+}
+
+input[type="date"]:hover::-webkit-calendar-picker-indicator,
+input[type="time"]:hover::-webkit-calendar-picker-indicator,
+input[type="datetime-local"]:hover::-webkit-calendar-picker-indicator,
+input[type="month"]:hover::-webkit-calendar-picker-indicator,
+input[type="week"]:hover::-webkit-calendar-picker-indicator,
+input[type="date"]:focus::-webkit-calendar-picker-indicator,
+input[type="time"]:focus::-webkit-calendar-picker-indicator,
+input[type="datetime-local"]:focus::-webkit-calendar-picker-indicator,
+input[type="month"]:focus::-webkit-calendar-picker-indicator,
+input[type="week"]:focus::-webkit-calendar-picker-indicator {
+  opacity: 1;
+}
+
+/* File input: wrap the native control in a consistent box and restyle its
+   built-in selector button to match the .nice-button family. */
+input[type="file"] {
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border-subtle);
+  padding: 6px 10px;
+  background: var(--surface-subtle);
+  color: var(--font-dark);
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease,
+    box-shadow 0.15s ease;
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+input[type="file"]:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+input[type="file"]:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+input[type="file"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  background: var(--surface-subtle);
+  border-color: var(--border-subtle);
+}
+
+input[type="file"]::file-selector-button {
+  margin-right: 12px;
+  border: 0;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--background-light);
+  color: var(--font-dark);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: var(--button-shadow);
+  transition: background-color 0.15s ease, color 0.15s ease,
+    box-shadow 0.2s ease;
+  letter-spacing: 0.01em;
+}
+
+input[type="file"]:hover::file-selector-button {
+  background: var(--accent);
+  color: var(--font-light);
+  box-shadow: var(--button-shadow-hover);
+}
+
+/* WebKit/Blink legacy pseudo-element (kept for older Safari/Chrome) */
+input[type="file"]::-webkit-file-upload-button {
+  margin-right: 12px;
+  border: 0;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--background-light);
+  color: var(--font-dark);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: var(--button-shadow);
+  transition: background-color 0.15s ease, color 0.15s ease,
+    box-shadow 0.2s ease;
+  letter-spacing: 0.01em;
+}
+
+input[type="file"]:hover::-webkit-file-upload-button {
+  background: var(--accent);
+  color: var(--font-light);
+  box-shadow: var(--button-shadow-hover);
+}
+
+/* Search input: hide the default clear button styling differences across browsers */
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 14px;
+  width: 14px;
+  background: var(--font-muted);
+  -webkit-mask: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 4l8 8M12 4l-8 8' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat center / contain;
+          mask: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 4l8 8M12 4l-8 8' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat center / contain;
+  cursor: pointer;
+}
+

--- a/frontend/booth/components/PageFooter.css
+++ b/frontend/booth/components/PageFooter.css
@@ -1,19 +1,22 @@
 .page-footer {
-  border-radius: 0 0 10px 10px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   background: var(--footer-background);
   color: var(--footer-font);
   text-align: center;
-  padding: 5px 2px;
+  padding: 12px 16px;
   line-height: 1.5em;
   font-size: 12px;
   min-height: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .page-footer a {
   color: var(--footer-link-font);
   text-decoration: none;
+  transition: opacity 0.15s ease;
 }
 
 .page-footer a:hover {
   text-decoration: underline;
+  opacity: 0.85;
 }

--- a/frontend/booth/components/PageHeader.css
+++ b/frontend/booth/components/PageHeader.css
@@ -1,9 +1,10 @@
 .page-header {
-  border-radius: 10px 10px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   background: var(--header-background);
   color: var(--header-font);
   display: flex;
   padding: 8px 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 @media screen and (max-width: 640px) {
@@ -63,10 +64,19 @@
 
 .page-header__titles__election-name,
 .page-header__titles__election-description {
-  line-height: 1.4em;
-  font-family: "Ubuntu", arial, serif;
-  font-weight: lighter;
+  line-height: 1.35em;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", arial, serif;
+  font-weight: 400;
   margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.page-header__titles__election-name {
+  font-weight: 500;
+}
+
+.page-header__titles__election-description {
+  opacity: 0.85;
 }
 
 .page-header__right {

--- a/frontend/booth/components/Progress.css
+++ b/frontend/booth/components/Progress.css
@@ -45,17 +45,22 @@
   position: relative;
   z-index: 2;
   margin: auto;
-  width: 6px;
-  height: 6px;
+  width: 10px;
+  height: 10px;
   border-radius: 100px;
   background-color: var(--background-light);
   border: 2px solid var(--progress-inactive);
   margin-bottom: 8px;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+.progress__step--current .progress__step__dot {
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
 }
 .line-left::before {
   content: "";
   position: absolute;
-  top: 5px;
+  top: 7px;
   right: 50%;
   left: 0;
   transform: translateY(-50%);
@@ -66,7 +71,7 @@
 .line-right::after {
   content: "";
   position: absolute;
-  top: 5px;
+  top: 7px;
   left: 50%;
   right: 0;
   transform: translateY(-50%);

--- a/frontend/booth/components/VoteNavigation.css
+++ b/frontend/booth/components/VoteNavigation.css
@@ -42,8 +42,8 @@
   display: flex;
   align-items: center;
   text-align: center;
-  color: #424242;
-  font-weight: bold;
+  color: var(--font-light);
+  font-weight: 500;
 }
 
 .vote-navigation__previous-button-container,

--- a/frontend/booth/components/common.css
+++ b/frontend/booth/components/common.css
@@ -33,6 +33,8 @@
   --body-background: #eef2f7;
   --surface-subtle: #f8fafc;
   --border-subtle: #e2e8f0;
+  --border-input: #94a3b8;
+  --border-input-hover: #64748b;
 
   --accent: #4f46e5;
   --accent-hover: #4338ca;

--- a/frontend/booth/components/common.css
+++ b/frontend/booth/components/common.css
@@ -24,55 +24,67 @@
 }
 
 :root {
-  /* most colors come from https://materialui.co/colors/ */
-  --font-light: #fafafa;
-  --font-dark: #212121;
-  --alert-text: #bf360c;
+  --font-light: #f8fafc;
+  --font-dark: #0f172a;
+  --font-muted: #64748b;
+  --alert-text: #c2410c;
 
-  --background-light: #fafafa;
-  --body-background: #e5e4e2;
+  --background-light: #ffffff;
+  --body-background: #eef2f7;
+  --surface-subtle: #f8fafc;
+  --border-subtle: #e2e8f0;
 
-  --box-blue: #e3f2fd;
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --accent-active: #3730a3;
+  --accent-soft: #eef2ff;
+
+  --box-blue: #eef2ff;
 
   --header-font: var(--font-light);
-  --header-background: #363636;
-  --footer-font: #9e9e9e;
-  --footer-link-font: #f5f5f5;
-  --footer-background: #363636;
+  --header-background: linear-gradient(135deg, #1e293b 0%, #312e81 100%);
+  --header-background-solid: #1e293b;
+  --footer-font: #cbd5e1;
+  --footer-link-font: #ffffff;
+  --footer-background: #0f172a;
 
-  --progress-active: #363636;
-  --progress-inactive: #757575;
+  --progress-active: var(--accent);
+  --progress-inactive: #cbd5e1;
 
-  --vote-nav-background: #757575;
+  --vote-nav-background: #475569;
   --review-ballot-background: var(--box-blue);
 
-  --button-default: #bdbdbd;
-  --button-default-hover: #9e9e9e;
-  --button-default-active: #757575;
-  --button-white: #fafafa;
-  --button-white-hover: #f5f5f5;
-  --button-white-active: #eeeeee;
-  --button-blue: #1976d2;
-  --button-blue-hover: #1565c0;
-  --button-blue-active: #0d47a1;
-  --button-grey: #757575;
-  --button-grey-hover: #616161;
-  --button-grey-active: #424242;
+  --button-default: #e2e8f0;
+  --button-default-hover: #cbd5e1;
+  --button-default-active: #94a3b8;
+  --button-white: #ffffff;
+  --button-white-hover: #f1f5f9;
+  --button-white-active: #e2e8f0;
+  --button-blue: var(--accent);
+  --button-blue-hover: var(--accent-hover);
+  --button-blue-active: var(--accent-active);
+  --button-grey: #475569;
+  --button-grey-hover: #334155;
+  --button-grey-active: #1e293b;
 
-  --candidate-background: #eeeeee;
-  --candidate-background-hover: #e0e0e0;
-  --candidate-background-checked: #bbdefb;
-  --candidate-background-checked-hover: #90caf9;
-  --candidate-checkbox-background: #fafafa;
-  --candidate-checkbox-border: #bdbdbd;
-  --candidate-checkbox-checked: #1976d2;
+  --candidate-background: #f1f5f9;
+  --candidate-background-hover: #e2e8f0;
+  --candidate-background-checked: #e0e7ff;
+  --candidate-background-checked-hover: #c7d2fe;
+  --candidate-checkbox-background: #ffffff;
+  --candidate-checkbox-border: #cbd5e1;
+  --candidate-checkbox-checked: var(--accent);
 
-  --page-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-    0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
-  --box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-    0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
-  --button-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2),
-    0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
-  --button-shadow-hover: 0px 2px 4px -1px rgba(0, 0, 0, 0.2),
-    0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  --page-shadow: 0 10px 25px -5px rgba(15, 23, 42, 0.10),
+    0 8px 10px -6px rgba(15, 23, 42, 0.06);
+  --box-shadow: 0 1px 2px 0 rgba(15, 23, 42, 0.05),
+    0 4px 12px -4px rgba(15, 23, 42, 0.08);
+  --button-shadow: 0 1px 2px 0 rgba(15, 23, 42, 0.08);
+  --button-shadow-hover: 0 4px 12px -2px rgba(79, 70, 229, 0.25),
+    0 2px 6px -1px rgba(15, 23, 42, 0.12);
+
+  --focus-ring: 0 0 0 3px rgba(79, 70, 229, 0.25);
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
 }

--- a/src/web/clients/admin/elections.ml
+++ b/src/web/clients/admin/elections.ml
@@ -960,6 +960,7 @@ let voters_content () =
                             max_voters);
                      ];
                    div
+                     ~a:[ a_class [ "textarea-with-tooltip" ] ]
                      [
                        tt;
                        div
@@ -1122,7 +1123,9 @@ let dates_content () =
       r##.value := Js.string "";
       sync ()
     in
-    div [ label; inp; btn_template; btn_erase ]
+    div
+      ~a:[ a_class [ "auto-date-row" ] ]
+      [ label; inp; btn_template; btn_erase ]
   in
   let datetime_local dt =
     {

--- a/src/web/static/MainMenu.css
+++ b/src/web/static/MainMenu.css
@@ -7,10 +7,11 @@
 
 .main-menu {
     flex: 1;
-    padding-left: 2px;
-    padding-right: 2px;
-    padding-bottom: 10px;
-    border-right: 1px solid black;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-bottom: 14px;
+    border-right: 1px solid var(--border-subtle);
+    background: var(--surface-subtle);
 }
 
 .main-menu > div:first-child {
@@ -19,31 +20,44 @@
 
 .main-menu__item, .main-menu__item-menutitle {
     min-height: 15px;
-    font-size: 80%;
-    margin-top:5px;
-    margin-bottom:5px;
-    padding-left:20px;
+    font-size: 13px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+    padding: 6px 10px 6px 14px;
+    border-radius: 6px;
+    transition: background-color 0.12s ease, color 0.12s ease;
 }
 
 .main-menu__item:hover {
-    background-color: #eee;
+    background-color: var(--accent-soft);
+    color: var(--accent);
 }
 
 .active, .active:hover {
-    background-color: rgb(255,160,120);
+    background-color: var(--accent);
+    color: var(--font-light);
+    font-weight: 500;
+}
+.active a, .active a:link, .active a:visited {
+    color: var(--font-light);
 }
 
 .main-menu__item-menutitle {
-    background-color: #ddd;
-    font-size: 90%;
-    padding-top: 3px;
-    padding-bottom: 3px;
-    margin-top: 20px;
+    background-color: transparent;
+    color: var(--font-muted);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-top: 6px;
+    padding-bottom: 4px;
+    margin-top: 18px;
 }
 
 .main-menu__item-separator {
     width: 100%;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid var(--border-subtle);
+    margin: 6px 0;
 }
 
 .main-menu__ddone, .main-menu__done, .main-menu__todo, .main-menu__doing, .main-menu__wip {
@@ -88,20 +102,14 @@
 }
 
 .main-menu__item-active {
-    background-image: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 0 0 L 10 5 0 10 Z' fill='rgb(255,160,120)' stroke-width='0'/%3E%3C/svg%3E");
-    background-size: contain;
-    background-repeat: no-repeat;
-    height: 15px;
-    width: 15px;
-    right: -15px;
-    display: block;
-    position: absolute;
+    display: none;
 }
 
 .unavailable {
-    color: #666;
+    color: var(--font-muted);
     font-style: italic;
-    background-color: #eee;
+    background-color: transparent;
+    opacity: 0.6;
 }
 
 .main-menu__button {

--- a/src/web/static/MainZone.css
+++ b/src/web/static/MainZone.css
@@ -8,41 +8,99 @@
 
 }
 
+/* Automatic dates: each row holds a label, a datetime/number input,
+   a "Set to..." template button and an "Erase" button. */
+.auto-date-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    margin: 14px 0;
+}
+
+.auto-date-row > label {
+    min-width: 7em;
+    font-weight: 500;
+    color: var(--font-dark);
+}
+
+.auto-date-row > input {
+    flex: 0 1 auto;
+    margin: 0;
+}
+
+.auto-date-row + .auto-date-row {
+    margin-top: 18px;
+}
+
 /* Pictures for delete / insert */
 
+div.ins_sym,
+div.del_sym {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 16px 16px;
+    background-color: transparent;
+    border: 1px solid transparent;
+    transition: background-color 0.15s ease, border-color 0.15s ease,
+        transform 0.08s ease;
+    flex-shrink: 0;
+    vertical-align: middle;
+}
+
 div.ins_sym {
-    width: 1.8ex;
-    height: 1.8ex;
-    background-image: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='5' cy='5' r='4.5' stroke='black' fill='none'/%3E%3Cpath d='M 5 2 V 8 M 2 5 H 8' stroke='black'/%3E%3C/svg%3E");
-    background-size: cover;
+    background-image: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 5 2 V 8 M 2 5 H 8' stroke='%234f46e5' stroke-width='1.4' stroke-linecap='round'/%3E%3C/svg%3E");
 }
 
 div.del_sym {
-    width: 1.8ex;
-    height: 1.8ex;
-    background-image: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='5' cy='5' r='4.5' stroke='black' fill='none'/%3E%3Cpath d='M 2.88 2.88 L 7.12 7.12 M 7.12 2.88 L 2.88 7.12' stroke='black'/%3E%3C/svg%3E");
-    background-size: cover;
+    background-image: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 2.88 2.88 L 7.12 7.12 M 7.12 2.88 L 2.88 7.12' stroke='%23dc2626' stroke-width='1.4' stroke-linecap='round'/%3E%3C/svg%3E");
+}
+
+div.ins_sym.clickable:hover {
+    background-color: var(--accent-soft);
+    border-color: var(--accent);
+    transform: scale(1.08);
+}
+
+div.del_sym.clickable:hover {
+    background-color: #fee2e2;
+    border-color: #dc2626;
+    transform: scale(1.08);
+}
+
+div.ins_sym.clickable:active,
+div.del_sym.clickable:active {
+    transform: scale(0.96);
 }
 
 
 /* Things for the question part */
 .question {
-    border: 1px solid black;
-    border-radius: 3px;
-    padding: 5px;
-    background-color: #f3f3f3;
-    margin-bottom: 10px;
-    margin-top: 10px;
-    margin-right: 40px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: 12px 14px;
+    padding-right: 18px;
+    background-color: var(--surface-subtle);
+    margin-bottom: 12px;
+    margin-top: 12px;
+    margin-right: 10px;
     font-size: 100%;
     position: relative;
+    box-shadow: var(--box-shadow);
 }
 
 .fake_question {
-    padding: 5px;
-    margin-bottom: 20px;
-    margin-top: 10px;
-    margin-right: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 8px 14px;
+    margin-bottom: 16px;
+    margin-top: 14px;
+    margin-right: 10px;
     font-size: 100%;
     position: relative;
 }
@@ -86,24 +144,44 @@ div.del_sym {
 }
 
 .expand_sort > div, .expand_grade > div, .expand_select > div {
-    margin-top: 5px;
-    padding: 5px;
+    margin-top: 8px;
+    padding: 14px 18px;
     width: 70%;
-    border: 1px solid black;
-    border-radius: 3px;
-    background-color: #f8f8f8;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background-color: var(--background-light);
+    box-shadow: var(--box-shadow);
 }
 
 .expand_select > div {
-    margin-left: 10px;
-    margin-right: auto;
-    width: 50%;
+    margin-left: 0;
+    margin-right: 0;
+    width: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-sizing: border-box;
+}
+
+.expand_select > div > div {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.expand_select > div > div label {
+    cursor: pointer;
+    user-select: none;
+    color: var(--font-dark);
+    flex: 1;
 }
 
 .expand_select input[type=number] {
-    width: 3em;
-    margin-top: 2px;
-    margin-bottom: 2px;
+    width: 4.5em;
+    margin: 0;
+    text-align: center;
+    padding: 6px 8px;
+    flex-shrink: 0;
 }
 
 .expand_sort > div {
@@ -118,7 +196,9 @@ div.del_sym {
 }
 
 .expand_sort input[type=number] {
-    width: 3em;
+    width: 4em;
+    padding: 6px 8px;
+    text-align: center;
 }
 
 .expand_grade input, .answers input {
@@ -166,7 +246,8 @@ div.del_sym {
 .fake_question > div:first-child {
     text-align: right;
     font-style: italic;
-    font-size: 110%;
+    font-size: 100%;
+    color: var(--font-muted);
 }
 
 .d_i_side {
@@ -179,8 +260,14 @@ div.del_sym {
 }
 
 .fake_question .d_i_side {
-    font-size: 130%;
-    left: calc(100% + 10px);
+    font-size: 100%;
+    position: static;
+    top: auto;
+    right: auto;
+    left: auto;
+    transform: none;
+    display: inline-flex;
+    align-items: center;
 }
 
 .d_i_side div {
@@ -190,17 +277,18 @@ div.del_sym {
 
 
 .d_i_side_top {
-    display: inline-block;
+    display: inline-flex;
+    gap: 6px;
     position: absolute;
-    top: 0px;
-    right: -50px;
-    font-size: 130%;
+    top: 12px;
+    right: 12px;
+    font-size: 100%;
     font-weight: bold;
 }
 
 .d_i_side_top div {
     display: inline-block;
-    margin-right: 5px;
+    margin-right: 0;
 }
 
 .mention .d_i_side, .answer .d_i_side {
@@ -230,18 +318,26 @@ div.del_sym {
 
 #previewbooth div {
     display: inline-block;
-    border: 2px solid #ccc;
-    border-radius: 10px;
-    padding: 5px;
-    background-color: #eee;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: 10px 18px;
+    background-color: var(--background-light);
+    color: var(--accent);
     font-size: 120%;
+    font-weight: 500;
     margin-top: 20px;
     margin-bottom: 20px;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease,
+        box-shadow 0.2s ease, transform 0.05s ease;
+    box-shadow: var(--button-shadow);
 }
 
 #previewbooth div:hover {
-    background-color: #ccc;
-    border-color: #aaa;
+    background-color: var(--accent-soft);
+    border-color: var(--accent);
+    box-shadow: var(--button-shadow-hover);
+    transform: translateY(-1px);
 }
 
 /* Things for the voters list part */
@@ -283,17 +379,24 @@ div.del_sym {
 }
 
 th {
-    color: white;
-    background-color: #49494b;
-    padding: 10px;
+    color: var(--font-dark);
+    background-color: var(--surface-subtle);
+    padding: 12px 14px;
     text-align: left;
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--border-subtle);
 }
 th:first-child {
     width: 50%;
+    border-top-left-radius: var(--radius-sm);
 }
 th:last-child {
     width: 10%;
-    background-color: white;
+    background-color: transparent;
+    border-top-right-radius: var(--radius-sm);
 }
 .ifw {
     width: 10%;
@@ -303,8 +406,8 @@ th:last-child {
 }
 
 td {
-    border-bottom: 1px solid black;
-    padding-left: 10px;
+    border-bottom: 1px solid var(--border-subtle);
+    padding: 10px 14px;
 }
 td:last-child {
     border-bottom: 0;
@@ -316,6 +419,9 @@ table {
     border-collapse: collapse;
     width: 100%;
 }
+tbody tr:hover {
+    background-color: var(--surface-subtle);
+}
 
 #addtolist {
     margin-top: 20px;
@@ -325,6 +431,19 @@ table {
     vertical-align:top;
 }
 
+/* Overlay the help "?" tooltip on the top-right corner of the textarea
+   so it doesn't get pushed below when the textarea is full-width. */
+.textarea-with-tooltip {
+    position: relative;
+}
+
+.textarea-with-tooltip > .tooltip {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 2;
+}
+
 .tooltip {
     position: relative;
     display: inline-block;
@@ -332,15 +451,35 @@ table {
 
 .tooltiptext {
     position:absolute;
-    right:3ex;
-    top: -3ex;
-    line-height:2.5ex;
-    border:1px solid black;
+    bottom: calc(100% + 10px);
+    right: 0;
+    left: auto;
+    top: auto;
+    line-height:1.5em;
+    border:1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
     font-size:90%;
     display:none;
-    width:400px;
-    padding:3px;
-    background-color:#eee;
+    width: 400px;
+    max-width: min(400px, calc(100vw - 40px));
+    padding:10px 12px;
+    background-color: var(--background-light);
+    color: var(--font-dark);
+    box-shadow: var(--box-shadow);
+    z-index: 10;
+    text-align: left;
+    font-weight: normal;
+    white-space: normal;
+}
+
+.tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    right: 6px;
+    border: 6px solid transparent;
+    border-top-color: var(--background-light);
+    margin-top: -1px;
 }
 
 .tooltip:hover .tooltiptext {
@@ -353,20 +492,26 @@ table {
     line-height:3ex;
     text-align:center;
     border-radius:1.5ex;
-    background-color:black;
-    color:white;
+    background-color: var(--accent);
+    color: var(--font-light);
+    font-weight: 600;
+    font-size: 11px;
 }
 
 .trustee-link {
-    border: solid 2px;
-    border-radius: 0.5em;
-    border-color: black;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--accent) !important;
+    background: var(--background-light);
+    padding: 4px 10px;
     white-space: nowrap;
+    transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .trustee-link:hover {
-    background-color: black !important;
-    color: white !important;
+    background-color: var(--accent) !important;
+    color: var(--font-light) !important;
+    border-color: var(--accent);
 }
 
 .trustee-links {

--- a/src/web/static/NavMenu.css
+++ b/src/web/static/NavMenu.css
@@ -2,30 +2,34 @@
     display: flex;
     flex-direction: row;
     background-color: var(--footer-background);
-    color: white;
+    color: var(--font-light);
     justify-content: space-between;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .nav-menu__item, .nav-menu__item-blank {
-    padding: 5px;
-    padding-left: 10px;
-    padding-right: 10px;
-    border-left-style: solid;
-    border-right-style: solid;
-    border-top-style: solid;
-    border-width: 2px;
+    padding: 8px 14px;
+    border-left: 1px solid rgba(255, 255, 255, 0.06);
+    border-right: 1px solid rgba(255, 255, 255, 0.06);
+    border-top: none;
+    transition: background-color 0.15s ease;
 }
 
 .nav-menu__item:hover {
-    background-color: #aaa;
+    background-color: rgba(255, 255, 255, 0.08);
 }
 
 .nav-menu__item-blank {
     flex-grow: 1;
+    border-left: none;
+    border-right: none;
 }
 
 #avatar {
     height: 1.8ex;
+    border-radius: 50%;
+    vertical-align: middle;
+    margin-right: 4px;
 }
 
 #nav_username {
@@ -35,5 +39,5 @@
 
 .nav-menu__item a {
     text-decoration: none;
-    color: white;
+    color: var(--font-light);
 }

--- a/src/web/static/app2.css
+++ b/src/web/static/app2.css
@@ -21,37 +21,54 @@
     left:0;
     bottom:0;
     right:0;
-    background-color:rgba(0,0,0,0.4);
+    background-color:rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
     z-index:99;
 }
 
 #popup-content {
-    border: 3px solid black;
-    border-radius: 5px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
     position: absolute;
     top: 50%;
     left: 50%;
     margin-right: -50%;
     transform: translate(-50%, -50%);
     z-index:100;
-    background-color:white;
-    padding: 10px;
+    background-color: var(--background-light);
+    padding: 20px 24px;
+    box-shadow: var(--page-shadow);
 }
 
 #prev_lk {
     text-align: center;
-    margin-top: 10px;
+    margin-top: 14px;
 }
 
 #prev_lk a {
-    border: 1px solid black;
-    border-radius: 2px;
-    background-color: #ddd;
-    padding: 3px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background-color: var(--background-light);
+    color: var(--accent);
+    padding: 6px 14px;
+    text-decoration: none;
+    font-weight: 500;
+    box-shadow: var(--button-shadow);
+    transition: background-color 0.15s ease, box-shadow 0.2s ease,
+        transform 0.05s ease;
+    display: inline-block;
+}
+
+#prev_lk a:hover {
+    background-color: var(--accent-soft);
+    box-shadow: var(--button-shadow-hover);
+    transform: translateY(-1px);
 }
 
 .txt_with_a a {
-    border-bottom: 1.5px dashed #222;
+    border-bottom: 1.5px dashed currentColor;
+    text-decoration: none;
 }
 
 #import_block {

--- a/src/web/static/common.css
+++ b/src/web/static/common.css
@@ -7,6 +7,13 @@ ul {
 #wrapper {
     min-height: 0px;
     font-size: 16px;
+    background: var(--header-background);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--page-shadow);
+}
+#main {
+    border-radius: var(--radius-lg);
 }
 #header {
     color: #ffffff;
@@ -25,18 +32,22 @@ button {
     text-align: center;
     font-size: 28px;
     padding-bottom: 28px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--font-dark);
 }
 .hybrid_box {
-    border-style: solid;
-    border-width: 1px;
-    background: #E5E5E5;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-subtle);
+    border-radius: var(--radius-md);
     margin-top: 2em;
     margin-bottom: 2em;
     margin-left: 10%;
     margin-right: 10%;
-    font-size: 80%;
-    padding: 3px;
-    line-height: 2.2ex;
+    font-size: 85%;
+    padding: 12px 16px;
+    line-height: 1.55;
+    box-shadow: var(--box-shadow);
 }
 .nh_explain {
     font-size: 90%;
@@ -44,7 +55,10 @@ button {
     font-style: italic;
 }
 .counting_method_specification {
-    border: 1px groove;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    background: var(--surface-subtle);
     margin-bottom: 2ex;
 }
 .result_question_item {
@@ -68,13 +82,19 @@ button {
 }
 .majority_judgment_result {
     margin: 1em;
-    border: 1px solid;
-    padding: 1em;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: 1em 1.2em;
+    background: var(--surface-subtle);
+    box-shadow: var(--box-shadow);
 }
 .schulze_result {
     margin: 1em;
-    border: 1px solid;
-    padding: 1em;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: 1em 1.2em;
+    background: var(--surface-subtle);
+    box-shadow: var(--box-shadow);
 }
 .schulze_result ol {
     margin-bottom: 1em;
@@ -100,20 +120,24 @@ button {
 
 /* table in election home */
 .home-audit {
-    background: #F5F5F5;
-    padding: 1em;
+    background: var(--surface-subtle);
+    border: 1px solid var(--border-subtle);
+    padding: 1.2em 1.4em;
     margin-top: 2em;
     margin-bottom: 2em;
     margin-left: 10%;
     margin-right: 10%;
-    font-size: 80%;
-    line-height: 2.2ex;
-    border-radius: 8px;
+    font-size: 85%;
+    line-height: 1.55;
+    border-radius: var(--radius-md);
     box-shadow: var(--box-shadow);
 }
 .home-audit__title {
-    font-size: 20px;
-    margin-bottom: .5em;
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: .6em;
+    letter-spacing: -0.01em;
+    color: var(--font-dark);
 }
 .home-audit table {
     border-top: none;
@@ -121,10 +145,10 @@ button {
 }
 .home-audit td {
     border-bottom: none;
-    padding: 4px;
+    padding: 6px 4px;
 }
 .home-audit tr:hover {
-    background-color: #E0E0E0;
+    background-color: var(--accent-soft);
 }
 .home-audit ul {
     padding-left: 1.2em;

--- a/src/web/static/responsive_site.css
+++ b/src/web/static/responsive_site.css
@@ -13,14 +13,20 @@
 @import "./NavMenu.css";
 
 #main {
-  padding: 10px;
+  padding: 18px;
 }
 
 body {
-  background: #E5E4E2;
-  font-family: Arial, Helvetica, sans-serif;
-  font-weight: lighter;
-  line-height: initial;
+  background: var(--body-background);
+  background-image: radial-gradient(at 0% 0%, rgba(79, 70, 229, 0.06) 0px, transparent 50%),
+                    radial-gradient(at 100% 0%, rgba(14, 165, 233, 0.05) 0px, transparent 50%);
+  background-attachment: fixed;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-weight: 400;
+  color: var(--font-dark);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @media screen and (max-width: 640px) {
@@ -31,16 +37,17 @@ body {
 
 @media screen and (min-width: 640px) {
   body {
-    margin: 8px;
+    margin: 16px;
   }
 }
 
 .page {
-  max-width: 800px;
+  max-width: 880px;
   margin: 0 auto;
   margin-bottom: 100px; /* leave some space for sticky footer */
   box-shadow: var(--page-shadow);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
 }
 
 .page-body {
@@ -48,8 +55,11 @@ body {
 }
 
 .cookie-disclaimer {
-  padding: 10px;
-  margin: 10px;
+  padding: 12px 16px;
+  margin: 12px;
+  background: var(--accent-soft);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
 }
 
 .sticky-footer {
@@ -57,9 +67,12 @@ body {
   left: 0;
   bottom: 0;
   width: 100%;
-  background-color: var(--background-light);
+  background-color: rgba(255, 255, 255, 0.92);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
   text-align: center;
-  border-top: 1px solid black;
+  border-top: 1px solid var(--border-subtle);
+  padding: 6px 0;
 }
 
 .container--center {
@@ -71,7 +84,15 @@ body {
 }
 
 .status--failure {
-    color: red;
+    color: #dc2626;
+}
+
+a {
+    color: var(--accent);
+    transition: color 0.15s ease;
+}
+a:hover {
+    color: var(--accent-hover);
 }
 
 #audit-footer {

--- a/vendor/css/styled-elements.css
+++ b/vendor/css/styled-elements.css
@@ -1,7 +1,7 @@
 table, td, th{vertical-align:middle;}
-table{border-collapse:separate;border-spacing:0;border-top:1px solid white;margin-bottom:28px;width:100%;text-align:left;}
-th{border-top:5px solid #555555;color:#ffffff;padding:10px;text-transform:uppercase;background-color:#49494b;}
-td{padding:10px;}
-td, th{border-bottom:1px solid #1f1f1f;}
+table{border-collapse:separate;border-spacing:0;border-top:none;margin-bottom:28px;width:100%;text-align:left;}
+th{border-top:none;color: var(--font-dark);padding:12px 14px;text-transform:uppercase;background-color: var(--surface-subtle);font-size:12px;letter-spacing:0.04em;font-weight:600;}
+td{padding:10px 14px;}
+td, th{border-bottom:1px solid var(--border-subtle);}
 .authentication-table {border: none;}
-.authentication-table td, .authentication-table th {border: none;}
+.authentication-table td, .authentication-table th {border: none;background:transparent;}


### PR DESCRIPTION
## Summary

Refreshes the visual design of both the booth and the admin SPA, without changing business logic or HTML structure beyond two small class additions. All work is concentrated in CSS files plus minor class-attribute tweaks in two OCaml files.

Highlights:
- **Design tokens**: a coherent palette (`--accent`, `--surface-subtle`, `--border-subtle`, …), radii, focus ring and shadows defined once in `common.css` and reused across booth + server bundles.
- **Typography & background**: system font stack (`-apple-system, "Segoe UI", Roboto…`) replaces Arial in the booth; body gets subtle radial-gradient accents and antialiasing. Headings keep Ubuntu with refined letter-spacing.
- **Inputs**: `input[type=text|password|email|number|search|url|tel|date|time|datetime-local|month|week]`, `input:not([type])`, `textarea` and `select` share one style with hover / focus / disabled / readonly states and a subtle inset shadow. Number-input spinners and date-picker indicators are toned down (opacity 0.55) and light up on hover/focus.
- **File inputs**: dashed-border wrapper that accents on hover; the `::file-selector-button` (and WebKit legacy pseudo) gets a button-like pill.
- **Buttons**: bare `<button>` and `<input type="submit|button|reset">` receive a consistent default style; the existing `.nice-button` family is excluded via `:not(.nice-button)` so its variants (`--blue`, `--white`, `--grey`, `--default`) keep winning the cascade.
- **Admin side menu (`MainMenu.css`)**: full redesign: section titles uppercased with muted color and letter-spacing, items get padding and rounded hover; the `active` item uses `--accent` with light text; legacy arrow indicator removed.
- **Top nav (`NavMenu.css`)**: semi-transparent dividers, hover background, rounded avatar.
- **Popup/modal (`app2.css`)**: `backdrop-filter: blur(2px)` on the overlay, refined border/radius/padding, `#prev_lk` rendered as a pill.
- **Booth chrome**: refined header/footer (typography, letter-spacing, subtle top border, hover opacity on footer links), larger `Progress.css` step dots (6 → 10 px) with a soft focus halo on the current step, candidate cards (`CandidateWithCheckbox.css`) gaining transitions + hover shadow, table headers (`styled-elements.css`) restyled with uppercase tracking.
- **Layout fixes**:
  - Automatic-dates rows use flex with `gap` so label / input / template button / Erase no longer touch each other (`.auto-date-row`).
  - The `?` help tooltip next to the voter-list textarea is overlaid in the textarea's top-right corner (`.textarea-with-tooltip`), so a full-width textarea no longer pushes it below; tooltip text is viewport-clamped (`max-width: min(400px, calc(100vw - 40px))`) so it cannot be cropped on the left.
  - `.fake_question` no longer overlaps the insert/delete side panel.
- **Ins/del symbols**: redesigned with accent-colored hover/active feedback.


## Scope of changes
Only CSS files plus two OCaml class additions:
- `frontend/booth/**` and `src/web/static/**`: CSS only.
- `src/web/clients/admin/elections.ml`: adds two `a_class` calls (`auto-date-row`, `textarea-with-tooltip`) -- no logic change.

No translations, no API, no cryptographic code, no build-system changes.

## Testing
Rebuilt locally and exercised the changes via the demo mode: created an election as admin (going through each draft tab ; Title, Questions, Voters, Dates, Trustees, etc.), then voted through the booth up to the recap. Forms, buttons, the voter-list tooltip, the automatic-dates row and the file/date inputs were checked visually in the running app.

## Notes for reviewers
- The `:not(.nice-button)` guard is intentional: a pseudo-class adds one class-level specificity component, so without it `button:hover` (0,1,1) would beat `.nice-button--blue` (0,1,0) on hover and break the variants.
- `input:not([type])` is included because `Common.input` (in `src/web/clients/common/common.ml`) produces `<input>` without a `type` attribute (e.g. `.qtit`, `.answers input`); browsers default these to text but CSS `input[type=text]` does not match them.
- `width: 100%` on `textarea` is intentional; the tooltip layout was reworked around it (overlay rather than sibling).
- This PR was mainly AI generated.